### PR TITLE
Adequação tagICMSSN Update Make.php

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -1323,8 +1323,7 @@ class Make
         $possible = [
             'item',
             'CST',
-            'indSN',
-            'indSemCST',
+            'indSN'
         ];
         $std = $this->equilizeParameters($std, $possible);
 
@@ -1342,14 +1341,7 @@ class Make
             $std->CSOSN,
             true,
             "[item $std->item] Indica se o contribuinte é Simples Nacional 1=Sim"
-        );
-        $this->dom->addChild(
-            $icmsSN,
-            'indSemCST',
-            $std->indSemCST,
-            true,
-            "[item $std->item] Sem Situação Tributária para o ICMS"
-        );
+        );       
         $this->aICMSSN[$std->item] = $icmsSN;
         return $icmsSN;
     }


### PR DESCRIPTION
Conforme documentação do "tagICMSSN", https://dfe-portal.svrs.rs.gov.br/NFCOM/ConsultaSchema não existe a propriedade "indSemCST", então gerar o xml com essa tag gera erro na validação do xml, apenas removi essa propriedade do array.