### PR TITLE
Update Make.php

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -48,6 +48,7 @@ class Make
     protected $aGIBSCBS = [];
     protected $aGIBSUF = [];
     protected $aGIBSMun = [];
+    protected $avIBS = [];
     protected $aGCBS = [];
     protected $aGTribRegular = [];
     protected $aGIBSCredPres = [];
@@ -1727,6 +1728,7 @@ class Make
         $possible = [
             'item',
             'vBC',
+            'vIBS'
         ];
         $std = $this->equilizeParameters($std, $possible);
 
@@ -1740,6 +1742,7 @@ class Make
             $identificador . "[item $std->item] Valor da Base de cálculo comum a IBS/CBS"
         );
         $this->aGIBSCBS[$std->item] = $gIBSCBS;
+        $this->avIBS[$std->item] = $std->vIBS;
         return $gIBSCBS;
     }
 
@@ -3484,6 +3487,11 @@ class Make
                     if (!empty($this->aGIBSMun[$nItem])) {
                         $child = $this->aGIBSMun[$nItem];
                         $this->dom->appChild($aGIBSCBS, $child, "Inclusão do node gIBSMun");
+                    }
+                    
+                    if (!empty($this->avIBS[$nItem])) {
+                        $vIBS = $this->avIBS[$nItem];              
+						$this->dom->addChild($aGIBSCBS, "vIBS", $vIBS, false, "Inclusão do node vIBS");
                     }
 
                     if (!empty($this->aGCBS[$nItem])) {


### PR DESCRIPTION
Conforme documentação do schema, temos:
campo 228 => vIBS
ao qual fica depois da tag gIBSMun e antes da tag gCBS com isso criei uma propriedade do tipo array chamada avIBS, pois eu não poderia adicionar a tag diretamente ela precisa está disponível no momento da montagem do bloco GIBSCS, 
veja que para informar o vIBS esse precisa ser informado ao ivocar a tagGIBSCBS
` public function tagGIBSCBS(stdClass $std)
    {
        $possible = [
            'item',
            'vBC',
			'vIBS'
        ];`

CONFORME TECHO:
`
if (!empty($this->aGIBSMun[$nItem])) {
                        $child = $this->aGIBSMun[$nItem];
                        $this->dom->appChild($aGIBSCBS, $child, "Inclusão do node gIBSMun");
                    }

                    if (!empty($this->avIBS[$nItem])) {
                        $vIBS = $this->avIBS[$nItem];              
						$this->dom->addChild($aGIBSCBS, "vIBS", $vIBS, false, "Inclusão do node vIBS");
                    }
					
                    if (!empty($this->aGCBS[$nItem])) {
                        $child = $this->aGCBS[$nItem];
                        $this->dom->appChild($aGIBSCBS, $child, "Inclusão do node gCBS");
                    }`

veja que adicionei no local correto, favor autorizar, inclusive gerei o xml assinei, e enviei e foi validado com sucesso.